### PR TITLE
fix count issue in check number of files changed in PR

### DIFF
--- a/.github/workflows/pr-file-check.yml
+++ b/.github/workflows/pr-file-check.yml
@@ -24,10 +24,11 @@ jobs:
         id: count
         run: |
           # Get the number of changed files
-          FILES_CHANGED=$(git diff --name-only origin/main... | wc -l)
-          echo "Changed files: $FILES_CHANGED"
+          FILES_CHANGED=$(git diff --name-only origin/main...)
 
           NON_INTERFACE_FILES=$(echo "$FILES_CHANGED" | grep -vE '^I' | wc -l)
+
+          echo "Changed files: $NON_INTERFACE_FILES"
 
           # Set the output variable
           echo "PR_FILES=$NON_INTERFACE_FILES" >> $GITHUB_ENV


### PR DESCRIPTION
Please make sure you checked this Practices [Link](https://app.clickup.com/36211933/v/dc/12h36x-62355/12h36x-38755)
# Description

- Updated bash script to accurately count changed files and exclude interface files (those starting with 'I').
- Fixed the logic to process file names instead of counting directly on a numeric value.
